### PR TITLE
update request to use /api prefix to match server and avoid path coll…

### DIFF
--- a/src/lib/request.js
+++ b/src/lib/request.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 export const timeout = 1 * 1000;
 export const request = axios.create({
-  // baseURL: 'localhost:4000',
+  baseURL: '/api',
   timeout: 1000,
   headers: {
     'Content-Type': 'application/json',


### PR DESCRIPTION
The api for menu factory has been updated to add an "api" prefix.  Update the axios calls to use the api prefix.  This change will help create a distinction between entity requests and http requests